### PR TITLE
Add additional information for Backblaze B2 to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ The build badge above is linked to this CI process.
          * Known compatible remotes: [directory](http://git-annex.branchable.com/special_remotes/directory/), [rsync](http://git-annex.branchable.com/special_remotes/rsync/)
       * `nodir` - No directory hierarchy is used.
          * On systems which are designed to efficiently deal with many objects in a single "directory" or "path", this is the simplest and most efficient layout.
-         * Backblaze's B2 API [specifically mentions](https://www.backblaze.com/b2/docs/files.html) that folders don't exist within buckets, so nodir would be the recommended layout.
          * Known compatible remotes:  Thomas Jost's [Hubic](https://github.com/Schnouki/git-annex-remote-hubic) remote when a swift container other than `default` is used.
       * `mixed` - A two-level mixed case directory hierarchy is used (using git-annex's DIRHASH format).
          * This layout may cause problems when used on filesystems and cloud storage providers that are case-insensitive.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The build badge above is linked to this CI process.
          * Known compatible remotes: [directory](http://git-annex.branchable.com/special_remotes/directory/), [rsync](http://git-annex.branchable.com/special_remotes/rsync/)
       * `nodir` - No directory hierarchy is used.
          * On systems which are designed to efficiently deal with many objects in a single "directory" or "path", this is the simplest and most efficient layout.
+         * Backblaze's B2 API [specifically mentions](https://www.backblaze.com/b2/docs/files.html) that folders don't exist within buckets, so nodir would be the recommended layout.
          * Known compatible remotes:  Thomas Jost's [Hubic](https://github.com/Schnouki/git-annex-remote-hubic) remote when a swift container other than `default` is used.
       * `mixed` - A two-level mixed case directory hierarchy is used (using git-annex's DIRHASH format).
          * This layout may cause problems when used on filesystems and cloud storage providers that are case-insensitive.
@@ -63,7 +64,7 @@ The build badge above is linked to this CI process.
       * Uses a `lower` repository layout
       * Stores your files in a folder/prefix called `git-annex`:
 
-    git annex initremote myacdremote type=external externaltype=rclone target=acd prefix=git-annex chunk=50MiB encryption=shared mac=HMACSHA512 rclone_layout=lower
+    `git annex initremote myacdremote type=external externaltype=rclone target=acd prefix=git-annex chunk=50MiB encryption=shared mac=HMACSHA512 rclone_layout=lower`
 
 The initremote command calls out to GPG and can hang if a machine has insufficient entropy. To debug issues, use the `--debug` flag, i.e. `git-annex initremote --debug`.
 


### PR DESCRIPTION
Hey hey, instead of creating an issue I thought I would make a PR. Backblaze's B2 doesn't utilize directories for buckets, and there is a huge speed penalty for using anything but `rclone_layout=nodir` so I thought it might be worth noting. :)
