### PR TITLE
Accept multiple instances as present

### DIFF
--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -191,8 +191,11 @@ while read -r line; do
 			key="$2"
 			calclocation "$key"
 
+			# Any nonzero object count means present.
+			# Some rclone backends support multiple
+			# files under one name.
 			if check_result=$(rclone size "$LOC$key" 2>&1) &&
-			    echo $check_result|grep 'Total objects: 1 Total size' >&2 &&
+			    echo $check_result|grep -E 'Total objects: [1-9][0-9]* Total size' >&2 &&
 			    ! echo $check_result|grep 'Total size: 0 (0 bytes)' >&2; then
 				echo CHECKPRESENT-SUCCESS "$key"
 			else


### PR DESCRIPTION
Some rclone backends (like Google Drive) can have multiple files with the same name.

This can happen under `git annex` (I think) if you try to upload the same file from two different locations simultaneously; you can have both uploads of a given chunk succeed and have two copies of the chunk in the remote.

If the chunks are identical, it doesn't seem to cause any problems retrieving the file (though you might end up downloading both copies of duplicated chunks and having one clobber the other), so the presence-checker ought to treat this case as the chunk being present (or at least not throw an error).