### PR TITLE
Bugfix for empty options

### DIFF
--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -81,6 +81,8 @@ ask () {
     resp="${resp%$'\r'}"
 	if echo $resp|grep '^VALUE '>/dev/null; then
 	    RET=$(echo "$resp" | cut -f2- -d' ')
+    	else
+	    RET=""
 	fi
 }
 


### PR DESCRIPTION
RET should be empty if an option wasn't specified. Otherwise prefix will propagate to target and target to layout if one of them is not given. Might lead to unexpected behaviour in some edge cases and the default setting for layout isn't reached as well.