### PR TITLE
unglobber the error stream

### DIFF
--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -199,14 +199,16 @@ while read -r line; do
 			# Some rclone backends support multiple
 			# files under one name.
 			if check_result=$(rclone size "$LOC$key" 2>&1) &&
-			    echo $check_result|grep -E 'Total objects: [1-9][0-9]* Total size' >&2 &&
-			    ! echo $check_result|grep 'Total size: 0 (0 bytes)' >&2; then
+			    totObjects=$(echo $check_result|grep -E 'Total objects: [1-9][0-9]* Total size' 2>&1) &&
+			    ! totSize=$(echo $check_result|grep 'Total size: 0 (0 bytes)' 2>&1) ; then
 				echo CHECKPRESENT-SUCCESS "$key"
+				echo "DEBUG grepping for Total objects led to ${totObjects}"
+				echo "DEBUG grepping for Total size led to ${totSize}"
 			else
 				# rclone 1.29 used 'Total objects: 0'
 				# rclone 1.30 uses 'directory not found'
-				if echo $check_result|grep 'Total objects: 0' >&2 || 
-				   echo $check_result|grep ' directory not found' >&2; then 
+				if totObjects=$(echo $check_result|grep 'Total objects: 0' 2>&1) || 
+				   dirNotFound=$(echo $check_result|grep ' directory not found' 2>&1); then 
 					echo CHECKPRESENT-FAILURE "$key"
 				else
 					# When the directory does not exist,
@@ -216,6 +218,8 @@ while read -r line; do
 					# if it couldn't be contacted).
 					echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
 				fi
+				echo "DEBUG grepping for Total objects led to ${totObjects}"
+				echo "DEBUG grepping for directory not found led to ${dirNotFound}"
 			fi
 		;;
 		REMOVE)


### PR DESCRIPTION
When checking if a file is present, the size function of rclone clobbers the output as described in issue #37.
That patch stores the error stream and the grepped result in variables.
These variables are printed with prefix DEBUG to stdout. That has the advantage, that git annex with debug flag, shows these messages.