### PR TITLE
fix: Support `size` output for new rclone

### DIFF
--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -199,7 +199,8 @@ while read -r line; do
 			# Some rclone backends support multiple
 			# files under one name.
 			if check_result=$(rclone size "$LOC$key" 2>&1) &&
-			    echo $check_result|grep -E 'Total objects: [1-9][0-9]* Total size' >&2 &&
+			    echo $check_result|grep -E 'Total objects: [1-9][0-9]*' >&2 &&
+			    echo $check_result|grep -E 'Total size' >&2 &&
 			    ! echo $check_result|grep 'Total size: 0 (0 bytes)' >&2; then
 				echo CHECKPRESENT-SUCCESS "$key"
 			else


### PR DESCRIPTION
Example output from rclone 1.57:

```text
Total objects: 1 (1)
Total size: 210.874 KiB (215935 Byte)
```

This is an alternative to #41, which, I suppose, will work both with old and new output formats? (I did not test it with old rclone, since I don’t have it.)