### PR TITLE
Switch to using JSON output of `rclone size`

### DIFF
--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -205,13 +205,12 @@ while read -r line; do
 				else
 					echo CHECKPRESENT-FAILURE "$key"
 				fi
-			else
-				# When the directory does not exist,
-				# the remote is not available.
-				# (A network remote would similarly
-				# fail with CHECKPRESENT-UNKNOWN
-				# if it couldn't be contacted).
-				echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
+			else  # Got an error, so the output is not JSON
+				if echo "$check_result" | grep 'directory not found' >/dev/null; then
+					echo CHECKPRESENT-FAILURE "$key"
+				else
+					echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
+				fi
 			fi
 		;;
 		REMOVE)

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -198,24 +198,20 @@ while read -r line; do
 			# Any nonzero object count means present.
 			# Some rclone backends support multiple
 			# files under one name.
-			if check_result=$(rclone size "$LOC$key" 2>&1) &&
-			    echo $check_result|grep -E 'Total objects: [1-9][0-9]* Total size' >&2 &&
-			    ! echo $check_result|grep 'Total size: 0 (0 bytes)' >&2; then
-				echo CHECKPRESENT-SUCCESS "$key"
-			else
-				# rclone 1.29 used 'Total objects: 0'
-				# rclone 1.30 uses 'directory not found'
-				if echo $check_result|grep 'Total objects: 0' >&2 || 
-				   echo $check_result|grep ' directory not found' >&2; then 
-					echo CHECKPRESENT-FAILURE "$key"
+			if check_result=$(rclone size --json "$LOC$key" 2>&1) &&
+			    echo "$check_result" | grep '"count":' >/dev/null; then
+				if echo "$check_result" | grep -E '"count":\s*[1-9][0-9]*' >/dev/null; then
+					echo CHECKPRESENT-SUCCESS "$key"
 				else
-					# When the directory does not exist,
-					# the remote is not available.
-					# (A network remote would similarly
-					# fail with CHECKPRESENT-UNKNOWN
-					# if it couldn't be contacted).
-					echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
+					echo CHECKPRESENT-FAILURE "$key"
 				fi
+			else
+				# When the directory does not exist,
+				# the remote is not available.
+				# (A network remote would similarly
+				# fail with CHECKPRESENT-UNKNOWN
+				# if it couldn't be contacted).
+				echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
 			fi
 		;;
 		REMOVE)


### PR DESCRIPTION
Example output from `rclone size --json`:

```text
{"count":1,"bytes":215935}
```

Much easier to parse, even with grep.

Obsoletes #42.