### PR TITLE
RF+ENH(TST): move all testing into a script which could be ran locally as well

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,23 @@
+name: Shellcheck
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Set up environment
+      uses: actions/checkout@v1
+   
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install shellcheck
+
+    - name: shellcheck
+      run: |
+        shellcheck git-annex-remote-rclone

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-18.04
@@ -25,7 +26,7 @@ jobs:
           # older versions for which there is internal logic
           - v1.33
           - v1.30
-          - v1.29
+          # - v1.29 TODO: seems to need rclone config run -- must be done in test script
 
     steps:
     - name: Set up environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-18.04
+          # TODO: use datalad-installer for git-annex and may be rclone
+          #- windows-2019
+          #- macos-latest
+
+    steps:
+    - name: Set up environment
+      uses: actions/checkout@v1
+   
+    - name: Install dependencies
+      run: |
+        curl 'https://downloads.kitenet.net/git-annex/linux/current/git-annex-standalone-amd64.tar.gz'|tar -xz -C /usr/local/bin --strip-components 1
+        curl 'https://downloads.rclone.org/rclone-current-linux-amd64.zip' > rclone.zip
+        unzip rclone.zip
+        mv rclone-*-linux-amd64/rclone /usr/local/bin
+
+    - name: ${{ matrix.module }} tests
+      run: |
+        tests/all-in-one.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,15 @@ jobs:
           # TODO: use datalad-installer for git-annex and may be rclone
           #- windows-2019
           #- macos-latest
+        rclone:
+          - current
+          - v1.58.1  # current "current" -- the baseline
+          - v1.53.3  # Debian bullseye (current stable)
+          - v1.45    # Debian buster (current oldstable)
+          # older versions for which there is internal logic
+          - v1.33
+          - v1.30
+          - v1.29
 
     steps:
     - name: Set up environment
@@ -24,8 +33,11 @@ jobs:
    
     - name: Install dependencies
       run: |
+        set -x
         curl 'https://downloads.kitenet.net/git-annex/linux/current/git-annex-standalone-amd64.tar.gz'|tar -xz -C /usr/local/bin --strip-components 1
-        curl 'https://downloads.rclone.org/rclone-current-linux-amd64.zip' > rclone.zip
+        test ${{ matrix.rclone }} = current && prefurl="" || prefurl="${{ matrix.rclone }}/"
+        curlurl="https://downloads.rclone.org/${prefurl}rclone-${{ matrix.rclone }}-linux-amd64.zip"
+        curl "$curlurl" > rclone.zip
         unzip rclone.zip
         mv rclone-*-linux-amd64/rclone /usr/local/bin
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
 
     - name: ${{ matrix.module }} tests
       run: |
-        tests/all-in-one.sh
+        PATH=$PWD:$PATH tests/all-in-one.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,14 +12,4 @@ test:
     - curl 'https://downloads.rclone.org/rclone-current-linux-amd64.zip' > rclone.zip
     - unzip rclone.zip
     - mv rclone-*-linux-amd64/rclone /usr/local/bin
-    - echo -e '[local]\ntype = local\nnounc =' > ~/.rclone.conf
-    - git-annex version
-    - mkdir testrepo
-    - cd testrepo
-    - git init .
-    - git-annex init
-    - git-annex initremote GA-rclone-CI type=external externaltype=rclone target=local prefix=/tmp/GA-rclone-CI chunk=100MiB encryption=shared mac=HMACSHA512
-    - touch test
-    - git-annex add test
-    - git-annex copy test --to GA-rclone-CI
-    - git-annex testremote GA-rclone-CI --fast
+    - tests/all-in-one.sh

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -67,7 +67,7 @@ calclocation () {
 			;;
 		frankencase)
 			ask DIRHASH "$1"
-			lret=$(echo $RET|tr A-Z a-z)
+			lret=$(echo "$RET" | tr '[:upper:]' '[:lower:]')
 			LOC="$REMOTE_TARGET:$REMOTE_PREFIX/$lret"
 			;;
 	esac
@@ -79,7 +79,7 @@ ask () {
 	read -r resp
     # Strip trailing carriage return, if present
     resp="${resp%$'\r'}"
-	if echo $resp|grep '^VALUE '>/dev/null; then
+	if echo "$resp" | grep '^VALUE '>/dev/null; then
 	    RET=$(echo "$resp" | cut -f2- -d' ')
     	else
 	    RET=""
@@ -93,6 +93,7 @@ echo VERSION 1
 while read -r line; do
     # Strip trailing carriage return, if present
     line="${line%$'\r'}"
+	# shellcheck disable=SC2086
 	set -- $line
 	case "$1" in
 		INITREMOTE)
@@ -119,18 +120,18 @@ while read -r line; do
 
 			getconfig target
 			REMOTE_TARGET=$RET
-			setconfig target $REMOTE_TARGET
+			setconfig target "$REMOTE_TARGET"
 			
 			getconfig rclone_layout
 			RCLONE_LAYOUT=$RET
 			validate_layout
-			setconfig rclone_layout $RCLONE_LAYOUT
+			setconfig rclone_layout "$RCLONE_LAYOUT"
 
 			if [ -z "$REMOTE_TARGET" ]; then
 		                echo INITREMOTE-FAILURE "rclone remote target must be specified (use target= parameter)"
 			fi
 
-            if runcmd rclone mkdir $REMOTE_TARGET:$REMOTE_PREFIX; then
+            if runcmd rclone mkdir "$REMOTE_TARGET:$REMOTE_PREFIX"; then
                 echo INITREMOTE-SUCCESS
             else
                 echo INITREMOTE-FAILURE "Failed to create directory on remote. Ensure that 'rclone config' has been run."
@@ -157,7 +158,7 @@ while read -r line; do
 			op="$2"
 			key="$3"
 			shift 3
-			file="$@"
+			file="$*"
 			case "$op" in
 				STORE)
 					# Store the file to a location
@@ -181,9 +182,9 @@ while read -r line; do
 					calclocation "$key"
 					# http://stackoverflow.com/questions/31396985/why-is-mktemp-on-os-x-broken-with-a-command-that-worked-on-linux
 					if GA_RC_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rclone-annex-tmp.XXXXXXXXX") &&
-					    runcmd rclone copy "$LOC$key" $GA_RC_TEMP_DIR &&
-					    mv $GA_RC_TEMP_DIR/$key $file &&
-					    rmdir $GA_RC_TEMP_DIR; then
+					    runcmd rclone copy "$LOC$key" "$GA_RC_TEMP_DIR" &&
+					    mv "$GA_RC_TEMP_DIR/$key" "$file" &&
+					    rmdir "$GA_RC_TEMP_DIR"; then
 						echo TRANSFER-SUCCESS RETRIEVE "$key"
 					else
 						echo TRANSFER-FAILURE RETRIEVE "$key"
@@ -199,14 +200,14 @@ while read -r line; do
 			# Some rclone backends support multiple
 			# files under one name.
 			if check_result=$(rclone size "$LOC$key" 2>&1) &&
-			    echo $check_result|grep -E 'Total objects: [1-9][0-9]*\>' >&2 &&
-			    ! echo $check_result|grep 'Total size: 0 (0 bytes)' >&2; then
+			    echo "$check_result"|grep -E 'Total objects: [1-9][0-9]*\>' >&2 &&
+			    ! echo "$check_result"|grep 'Total size: 0 (0 bytes)' >&2; then
 				echo CHECKPRESENT-SUCCESS "$key"
 			else
 				# rclone 1.29 used 'Total objects: 0'
 				# rclone 1.30 uses 'directory not found'
-				if echo $check_result|grep 'Total objects: 0' >&2 || 
-				   echo $check_result|grep ' directory not found' >&2; then 
+				if echo "$check_result"|grep 'Total objects: 0' >&2 || 
+				   echo "$check_result"|grep ' directory not found' >&2; then 
 					echo CHECKPRESENT-FAILURE "$key"
 				else
 					# When the directory does not exist,
@@ -229,9 +230,9 @@ while read -r line; do
 	    		   	# rclone 1.29 used Failed to purge: Couldn't find directory:
 				# rclone 1.30 used no such file or directory
 				# rclone 1.33 uses directory not found
-		                if echo $remove_result | grep " Failed to purge: Couldn't find directory: " >&2 ||
-				   echo $remove_result | grep ' no such file or directory' ||
-				   echo $remove_result | grep ' directory not found' >&2
+		                if echo "$remove_result" | grep " Failed to purge: Couldn't find directory: " >&2 ||
+				   echo "$remove_result" | grep ' no such file or directory' ||
+				   echo "$remove_result" | grep ' directory not found' >&2
 				then   
 					echo REMOVE-SUCCESS "$key"
 		                else

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -199,7 +199,7 @@ while read -r line; do
 			# Some rclone backends support multiple
 			# files under one name.
 			if check_result=$(rclone size "$LOC$key" 2>&1) &&
-			    echo $check_result|grep -E 'Total objects: [1-9][0-9]* Total size' >&2 &&
+			    echo $check_result|grep -E 'Total objects: [1-9][0-9]*\>' >&2 &&
 			    ! echo $check_result|grep 'Total size: 0 (0 bytes)' >&2; then
 				echo CHECKPRESENT-SUCCESS "$key"
 			else

--- a/tests/all-in-one.sh
+++ b/tests/all-in-one.sh
@@ -29,7 +29,7 @@ git-annex initremote GA-rclone-CI type=external externaltype=rclone target=local
 #  git-annex: .git/annex/tmp/SHA256E-s0--e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855: rename: does not exist (No such file or directory)
 #  failed
 # without even talking to the rclone remote!
-touch "test 0"
+# touch "test 0"
 
 echo 1 > "test 1"
 git-annex add *

--- a/tests/all-in-one.sh
+++ b/tests/all-in-one.sh
@@ -47,11 +47,11 @@ git-annex get *
 set +x
 for f in `seq 1 100`; do echo "load $f" | tee "test-$f.dat" >| "test $f.dat"; done
 set -x
-git annex add -J5 .
-git-annex copy -J5 . --to GA-rclone-CI
-git-annex drop -J5 .
-git-annex get -J5 .
-git-annex drop --from GA-rclone-CI -J5 .
+git annex add -J5 --quiet .
+git-annex copy -J5 --quiet . --to GA-rclone-CI
+git-annex drop -J5 --quiet .
+git-annex get -J5 --quiet .
+git-annex drop --from GA-rclone-CI -J5 --quiet .
 
 # annex testremote --fast
 git-annex testremote GA-rclone-CI --fast

--- a/tests/all-in-one.sh
+++ b/tests/all-in-one.sh
@@ -18,9 +18,7 @@ mkdir testrepo
 cd testrepo
 git init .
 git-annex init
-git-annex initremote GA-rclone-CI type=external externaltype=rclone target=local prefix=$RCLONE_PREFIX chunk=100MiB encryption=none
-
-#shared mac=HMACSHA512
+git-annex initremote GA-rclone-CI type=external externaltype=rclone target=local prefix=$RCLONE_PREFIX chunk=100MiB encryption=shared mac=HMACSHA512
 
 # Rudimentary test, spaces in the filename must be ok, 0 length files should be ok
 

--- a/tests/all-in-one.sh
+++ b/tests/all-in-one.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
 cd "$(mktemp -d ${TMPDIR:-/tmp}/dl-XXXXXXX)"
+
 set -eux
 
+# provide versioning information to possibly ease troubleshooting
+git annex version
+rclone --version
 
 export HOME=$PWD
 echo -e '[local]\ntype = local\nnounc =' > ~/.rclone.conf
+# to pacify git/git-annex
 git config --global user.name Me
 git config --global user.email me@example.com
+git config --global init.defaultBranch master
 
 # Prepare rclone remote local store
 mkdir rclone-local

--- a/tests/all-in-one.sh
+++ b/tests/all-in-one.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+cd "$(mktemp -d ${TMPDIR:-/tmp}/dl-XXXXXXX)"
+set -eux
+
+
+export HOME=$PWD
+echo -e '[local]\ntype = local\nnounc =' > ~/.rclone.conf
+git config --global user.name Me
+git config --global user.email me@example.com
+
+# Prepare rclone remote local store
+mkdir rclone-local
+export RCLONE_PREFIX=$PWD/rclone-local
+
+git-annex version
+mkdir testrepo
+cd testrepo
+git init .
+git-annex init
+git-annex initremote GA-rclone-CI type=external externaltype=rclone target=local prefix=$RCLONE_PREFIX chunk=100MiB encryption=none
+
+#shared mac=HMACSHA512
+
+# Rudimentary test, spaces in the filename must be ok, 0 length files should be ok
+
+# TODO: Working with 0-sized file fails for @yarikoptic!
+# doesn't work with git-annex 8.20211123-1 10.20220504-1
+# kabooms with
+#  (from GA-rclone-CI...)
+#  git-annex: .git/annex/tmp/SHA256E-s0--e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855: rename: does not exist (No such file or directory)
+#  failed
+# without even talking to the rclone remote!
+touch "test 0"
+
+echo 1 > "test 1"
+git-annex add *
+git-annex copy * --to GA-rclone-CI
+git-annex drop *
+git-annex get *
+
+# test copy/drop/get cycle with parallel execution and good number of files and spaces in the names, and duplicated content/keys
+set +x
+for f in `seq 1 100`; do echo "load $f" | tee "test-$f.dat" >| "test $f.dat"; done
+set -x
+git annex add -J5 .
+git-annex copy -J5 . --to GA-rclone-CI
+git-annex drop -J5 .
+git-annex get -J5 .
+git-annex drop --from GA-rclone-CI -J5 .
+
+# annex testremote --fast
+git-annex testremote GA-rclone-CI --fast


### PR DESCRIPTION
It also extends testing with actually getting the file.  Original file of 0 length getting
does not work for me at all! See comment in the code.  I left it in (to see if would work on gitlab CI), and if fails on CI
better be disabled until fixed. For file of size 1 -- works ok, and works ok with the trickier
tests later on (again non-0 size).

not sure if somehow integrated with gitlab to pick up this PR at https://gitlab.com/DanielDent/git-annex-remote-rclone/-/pipelines -- will see.  If not -- might be worth establishing github action may be?

I didn't dare to refactor tests to use some proper testing framework (shunit2 or bats). But could be done I guess.