### PR TITLE
ENH: do not channel grep to stderr by default, react to GARR_DEBUG for that

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - name: Set up environment
       uses: actions/checkout@v1
-   
+
     - name: Install dependencies
       run: |
         set -x
@@ -45,3 +45,5 @@ jobs:
     - name: ${{ matrix.module }} tests
       run: |
         PATH=$PWD:$PATH tests/all-in-one.sh
+        # Should work with debug enabled as well
+        GARR_DEBUG=1 PATH=$PWD:$PATH tests/all-in-one.sh

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ interrupted or if some move operations do not complete successfully. When runnin
 At this time, this remote does NOT store your credentials in git-annex. Users are responsible for ensuring a
 ~/.rclone.conf file with valid credentials is available.
 
+## Troubleshooting
+
+Setting environment variable `GARR_DEBUG` to non-empty value would make `git-annex-remote-rclone` output results of `grep` operations to stderr which could help in troubleshooting.
+
 ## Warning
 
 Not all of the supported cloud storage providers have been tested. While in theory any provider that works with rclone

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -89,6 +89,17 @@ ask () {
 	fi
 }
 
+# If GARR_DEBUG variable is set to some value, output from grep
+# will be provided on stderr for debugging purposes.
+if [ -n "${GARR_DEBUG:-}" ]; then
+	GREP () {
+		grep "$@" >&2
+	}
+else
+	GREP () {
+		grep -q "$@" &>/dev/null
+	}
+fi
 
 # This has to come first, to get the protocol started.
 echo VERSION 1
@@ -203,14 +214,14 @@ while read -r line; do
 			# Some rclone backends support multiple
 			# files under one name.
 			if check_result=$(rclone size "$LOC$key" 2>&1) &&
-				echo "$check_result"|grep -E 'Total objects: [1-9][0-9]*\>' >&2 &&
-				! echo "$check_result"|grep 'Total size: 0 (0 bytes)' >&2; then
+				echo "$check_result" | GREP -E 'Total objects: [1-9][0-9]*\>' &&
+				! echo "$check_result" | GREP 'Total size: 0 (0 bytes)'; then
 				echo CHECKPRESENT-SUCCESS "$key"
 			else
 				# rclone 1.29 used 'Total objects: 0'
 				# rclone 1.30 uses 'directory not found'
-				if echo "$check_result"|grep 'Total objects: 0' >&2 ||
-				   echo "$check_result"|grep ' directory not found' >&2; then
+				if echo "$check_result" | GREP 'Total objects: 0' ||
+				   echo "$check_result" | GREP ' directory not found'; then
 					echo CHECKPRESENT-FAILURE "$key"
 				else
 					# When the directory does not exist,
@@ -233,9 +244,9 @@ while read -r line; do
 				# rclone 1.29 used Failed to purge: Couldn't find directory:
 				# rclone 1.30 used no such file or directory
 				# rclone 1.33 uses directory not found
-				if echo "$remove_result" | grep " Failed to purge: Couldn't find directory: " >&2 ||
-					echo "$remove_result" | grep ' no such file or directory' ||
-					echo "$remove_result" | grep ' directory not found' >&2
+				if echo "$remove_result" | GREP " Failed to purge: Couldn't find directory: " ||
+					echo "$remove_result" | GREP ' no such file or directory' ||
+					echo "$remove_result" | GREP ' directory not found' >&2
 				then
 					echo REMOVE-SUCCESS "$key"
 				else


### PR DESCRIPTION
Dumping all those grep outputs to the screen can
- confuse user (like it did me -- are those "no such directory" errors for me to worry?)
- flood stderr leading "naive"ly coded outside getting stuck if reading both
  stdout and stderr.

For that, by default, operation of git-annex-remote-rclone should proceed
silently.

Alternative to
- #38, fixes #37 (via assigning grep output to a variable)
- #31 which always makes `grep` silent