### PR TITLE
ENH: do not channel grep to stderr by default, capture and send to annex via DEBUG msg

### DIFF
--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -97,8 +97,9 @@ GREP () {
 	# Replace explicit newline since we must provide 1 line DEBUG
 	# Fancy sed is from Example 5 of https://linuxhint.com/newline_replace_sed
 	# which worked on Linux and OSX.
+	# shellcheck disable=SC2016
 	out_safe=$(echo "$out" | sed -ne 'H;${x;s/\n/\\n/g;s/^,//;p;}')
-	echo "DEBUG 'grep \"$@\"' exited with rc=$rc and stdout=${out_safe}"
+	echo "DEBUG 'grep \"$*\"' exited with rc=$rc and stdout=${out_safe}"
 	exit $rc
 }
 

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -89,6 +89,18 @@ ask () {
 	fi
 }
 
+GREP () {
+	set +e
+	out=$(grep "$@")
+	rc=$?
+	set -e
+	# Replace explicit newline since we must provide 1 line DEBUG
+	# Fancy sed is from Example 5 of https://linuxhint.com/newline_replace_sed
+	# which worked on Linux and OSX.
+	out_safe=$(echo "$out" | sed -ne 'H;${x;s/\n/\\n/g;s/^,//;p;}')
+	echo "DEBUG 'grep \"$@\"' exited with rc=$rc and stdout=${out_safe}"
+	exit $rc
+}
 
 # This has to come first, to get the protocol started.
 echo VERSION 1
@@ -203,14 +215,14 @@ while read -r line; do
 			# Some rclone backends support multiple
 			# files under one name.
 			if check_result=$(rclone size "$LOC$key" 2>&1) &&
-				echo "$check_result"|grep -E 'Total objects: [1-9][0-9]*\>' >&2 &&
-				! echo "$check_result"|grep 'Total size: 0 (0 bytes)' >&2; then
+				echo "$check_result" | GREP -E 'Total objects: [1-9][0-9]*\>' &&
+				! echo "$check_result" | GREP 'Total size: 0 (0 bytes)'; then
 				echo CHECKPRESENT-SUCCESS "$key"
 			else
 				# rclone 1.29 used 'Total objects: 0'
 				# rclone 1.30 uses 'directory not found'
-				if echo "$check_result"|grep 'Total objects: 0' >&2 ||
-				   echo "$check_result"|grep ' directory not found' >&2; then
+				if echo "$check_result" | GREP 'Total objects: 0' ||
+				   echo "$check_result" | GREP ' directory not found'; then
 					echo CHECKPRESENT-FAILURE "$key"
 				else
 					# When the directory does not exist,
@@ -233,9 +245,9 @@ while read -r line; do
 				# rclone 1.29 used Failed to purge: Couldn't find directory:
 				# rclone 1.30 used no such file or directory
 				# rclone 1.33 uses directory not found
-				if echo "$remove_result" | grep " Failed to purge: Couldn't find directory: " >&2 ||
-					echo "$remove_result" | grep ' no such file or directory' ||
-					echo "$remove_result" | grep ' directory not found' >&2
+				if echo "$remove_result" | GREP " Failed to purge: Couldn't find directory: " ||
+					echo "$remove_result" | GREP ' no such file or directory' ||
+					echo "$remove_result" | GREP ' directory not found'
 				then
 					echo REMOVE-SUCCESS "$key"
 				else

--- a/tests/all-in-one.sh
+++ b/tests/all-in-one.sh
@@ -43,6 +43,10 @@ git-annex copy * --to GA-rclone-CI
 git-annex drop *
 git-annex get *
 
+# Do a cycle with --debug to ensure that we are passing desired DEBUG output
+git-annex --debug drop test\ 1 2>&1 | grep -q 'grep.*exited with rc='
+git-annex --debug get test\ 1 2>/dev/null
+
 # test copy/drop/get cycle with parallel execution and good number of files and spaces in the names, and duplicated content/keys
 set +x
 for f in `seq 1 100`; do echo "load $f" | tee "test-$f.dat" >| "test $f.dat"; done


### PR DESCRIPTION
Dumping all those grep outputs to the screen can
- confuse user (like it did me -- are those "no such directory" errors for me to worry?)
- flood stderr leading "naive"ly coded outside getting stuck if reading both
  stdout and stderr.

For that, by default, operation of git-annex-remote-rclone should proceed
silently, and only with --debug would show corresponding exit code and output

Alternative to
- #48, which is adding a new env var
- #38, fixes #37 (via assigning grep output to a variable) with "echo DEBUG"
  then for each such variable.  This PR could be considered a "centralized version"
  of that PR which also safe-guards against multiline output
- #31 which always makes `grep` silent