### PR TITLE
ENH(TST): enable testing on empty file with a recent git-annex

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,5 @@ jobs:
     - name: ${{ matrix.module }} tests
       run: |
         PATH=$PWD:$PATH tests/all-in-one.sh
+        # Test without encryption so we do get 0-sized files in rclone remote store
+        PATH=$PWD:$PATH GARR_TEST_ENCRYPTION=none tests/all-in-one.sh

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -216,8 +216,7 @@ while read -r line; do
 			# Some rclone backends support multiple
 			# files under one name.
 			if check_result=$(rclone size "$LOC$key" 2>&1) &&
-				echo "$check_result" | GREP -E 'Total objects: [1-9][0-9]*\>' &&
-				! echo "$check_result" | GREP 'Total size: 0 (0 bytes)'; then
+				echo "$check_result" | GREP -E 'Total objects: [1-9][0-9]*\>'; then
 				echo CHECKPRESENT-SUCCESS "$key"
 			else
 				# rclone 1.29 used 'Total objects: 0'

--- a/tests/all-in-one.sh
+++ b/tests/all-in-one.sh
@@ -58,7 +58,7 @@ git-annex --debug get test\ 1 2>/dev/null
 
 # test copy/drop/get cycle with parallel execution and good number of files and spaces in the names, and duplicated content/keys
 set +x
-for f in `seq 1 100`; do echo "load $f" | tee "test-$f.dat" >| "test $f.dat"; done
+for f in `seq 1 20`; do echo "load $f" | tee "test-$f.dat" >| "test $f.dat"; done
 set -x
 git annex add -J5 --quiet .
 git-annex copy -J5 --quiet . --to GA-rclone-CI

--- a/tests/all-in-one.sh
+++ b/tests/all-in-one.sh
@@ -37,7 +37,7 @@ mkdir testrepo
 cd testrepo
 git init .
 git-annex init
-git-annex initremote GA-rclone-CI type=external externaltype=rclone target=local prefix=$RCLONE_PREFIX chunk=100MiB encryption=shared mac=HMACSHA512
+git-annex initremote GA-rclone-CI type=external externaltype=rclone target=local prefix=$RCLONE_PREFIX chunk=100MiB encryption=${GARR_TEST_ENCRYPTION:-shared} mac=HMACSHA512
 
 # Rudimentary test, spaces in the filename must be ok, 0 length files should be ok
 if verlte "10.20220525+git73" "$git_annex_version"; then


### PR DESCRIPTION
With #51 done, may be we would add "snapshot" build run of git-annex to actually test this

<details>
<summary> tested locally with git-annex `10.20220525+git77-gc0e648e92-1~ndall+1` and it worked ok:</summary> 

```
+ verlte 10.20220525+git73 10.20220525+git77-gc0e648e92-1~ndall+1
++ echo -e '10.20220525+git73\n10.20220525+git77-gc0e648e92-1~ndall+1'
++ sort -V
++ head -n1
+ '[' 10.20220525+git73 = 10.20220525+git73 ']'
+ echo 'I: Fixed git-annex 10.20220525+git77-gc0e648e92-1~ndall+1, adding empty file'
I: Fixed git-annex 10.20220525+git77-gc0e648e92-1~ndall+1, adding empty file
+ touch 'test 0'
+ echo 1
+ git-annex add 'test 0' 'test 1'
add test 0 
ok
add test 1 
ok                                
(recording state in git...)
+ git-annex copy 'test 0' 'test 1' --to GA-rclone-CI
copy test 0 (to GA-rclone-CI...) 
ok
copy test 1 (to GA-rclone-CI...) 
ok
(recording state in git...)
+ git-annex drop 'test 0' 'test 1'
drop test 0 ok
drop test 1 ok
(recording state in git...)
+ git-annex get 'test 0' 'test 1'
get test 0 (from GA-rclone-CI...) 
ok
get test 1 (from GA-rclone-CI...) 
(checksum...) ok
(recording state in git...)
+ git-annex --debug drop 'test 1'
+ grep -q 'grep.*exited with rc='
```
</details>

- while working on that reviewed that questionable matching based on size of 0Bs and discovered that current rclone has different format (`Total size: 0 B (0 Byte)`) instead of "coded in" (`Total size: 0 (0 bytes)`) so it didn't result in match, and 0 sized file was dropped/obtained just fine ;)
- adds helpers to do version comparison based on `sort -V` - might come handy
- to test really on having 0-length file in remote, had to disable encryption, thus made that "parametric" and diluted test specification a little into github workflow by making two runs to the tests . 