### PR TITLE
Update copyright end year for Daniel, add myself

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ Please submit a pull request or create a new issue for problems or potential imp
 
 ## License
 
-Copyright 2016-2022 [Daniel Dent](https://www.danieldent.com/), 2022 [Yaroslav O. Halchenko](https://centerforopenneuroscience.org/). Licensed under the GPLv3.
+Copyright 2016-2022 [Daniel Dent](https://www.danieldent.com/), 2022 [git-annex-remote-rclone contributors](https://github.com/DanielDent/git-annex-remote-rclone/graphs/contributors). Licensed under the GPLv3.

--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ Please submit a pull request or create a new issue for problems or potential imp
 
 ## License
 
-Copyright 2016-2017 [Daniel Dent](https://www.danieldent.com/). Licensed under the GPLv3.
+Copyright 2016-2022 [Daniel Dent](https://www.danieldent.com/), 2022 [Yaroslav O. Halchenko](https://centerforopenneuroscience.org/). Licensed under the GPLv3.

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -6,7 +6,8 @@
 #
 # Install in PATH as git-annex-remote-rclone
 #
-# Copyright (C) 2016-2017  Daniel Dent
+# Copyright (C) 2016-2022  Daniel Dent
+#               2022       Yaroslav O. Halchenko
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of version 3 of the GNU
 # General Public License as published by the Free Software Foundation.

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -7,7 +7,7 @@
 # Install in PATH as git-annex-remote-rclone
 #
 # Copyright (C) 2016-2022  Daniel Dent
-#               2022       Yaroslav O. Halchenko
+#               2022       git-annex-remote-rclone contributors
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of version 3 of the GNU
 # General Public License as published by the Free Software Foundation.


### PR DESCRIPTION
IMHO it is valuable to keep years up to date to signal users that
project is live etc.  Added myself on the fact of contribution.

An alternative could be to replace named copyrights with more
encapsulating

    2022 git-annex-remote-rclone contributors

e.g. for myself only or for everyone (including Daniel), your call