### PR TITLE
Fix CHECKPRESENT problems

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -21,3 +21,4 @@ jobs:
     - name: shellcheck
       run: |
         shellcheck git-annex-remote-rclone
+        shellcheck tests/mock-git-annex

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,6 @@ jobs:
 
     - name: ${{ matrix.module }} tests
       run: |
-        PATH=$PWD:$PATH tests/all-in-one.sh
+        PATH=$PWD:$PWD/tests:$PATH all-in-one.sh
         # Test without encryption so we do get 0-sized files in rclone remote store
-        PATH=$PWD:$PATH GARR_TEST_ENCRYPTION=none tests/all-in-one.sh
+        PATH=$PWD:$PWD/tests:$PATH GARR_TEST_ENCRYPTION=none all-in-one.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,8 @@ jobs:
           - macos-latest
         rclone:
           - current
-          - v1.58.1  # current "current" -- the baseline
+          - v1.59.2
+          - v1.58.1
           - v1.53.3  # Debian bullseye (current stable)
           - v1.45    # Debian buster (current oldstable)
         exclude:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,14 +22,7 @@ jobs:
           - v1.58.1  # current "current" -- the baseline
           - v1.53.3  # Debian bullseye (current stable)
           - v1.45    # Debian buster (current oldstable)
-          # older versions for which there is internal logic
-          - v1.33
-          - v1.30
-          # - v1.29 TODO: seems to need rclone config run -- must be done in test script
         exclude:
-          # 1.30 - --version exits non-0
-          - os: macos-latest
-            rclone: v1.30
           # 1.45 - has some odd handling of HOME on OSX - does not use overloaded $HOME
           - os: macos-latest
             rclone: v1.45

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Cloud storage providers supported by rclone currently include:
 
 The current version of git-annex-remote-rclone has been tested with rclone versions up to 1.37. Because rclone sometimes changes its output, updates to this software may be required for compatibility.
 
-Version 1.34 of rclone includes performance improvements and for that reason is now the minimum recommended version. 
+Version 1.45 of rclone introduces a more stable JSON output mode on some commands and for that reason is now the minimum version.
 
 To simplify maintenance, when I make updates to git-annex-remote-rclone, I test only against the current stable
 version of rclone. While I am not currently explicitly dropping support for older versions, I am also not

--- a/README.md
+++ b/README.md
@@ -29,16 +29,18 @@ Cloud storage providers supported by rclone currently include:
 
 ## Requirements
 
-The current version of git-annex-remote-rclone has been tested with rclone versions up to 1.37. Because rclone sometimes changes its output, updates to this software may be required for compatibility.
+Because rclone sometimes changes its output, updates to this software may be required for compatibility.
+Version 1.45 of rclone introduces a more stable JSON output mode on some commands and for that reason is the minimum supported version.
 
-Version 1.45 of rclone introduces a more stable JSON output mode on some commands and for that reason is now the minimum version.
+A periodic continuous integration process tests compatibility against
+the latest stable release of `git-annex` and the following versions of `rclone`:
 
-To simplify maintenance, when I make updates to git-annex-remote-rclone, I test only against the current stable
-version of rclone. While I am not currently explicitly dropping support for older versions, I am also not
-performing additional integration tests with older rclone versions.
+- the latest stable release at time of testing
+- 1.59.2 (the latest stable release at time of writing)
+- 1.58.1
+- 1.53.3
+- 1.45 (Linux only)
 
-A periodic continuous integration process downloads the latest stable releases
-of `rclone` and `git-annex` and runs `git-annex testremote` to verify compatibility.
 The build badge above is linked to this CI process.
 
 ## Usage

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -215,7 +215,7 @@ while read -r line; do
 			
 			res=0
 			check_result=$(rclone size --json "$LOC$key") || res=$?
-			count=$(echo "$check_result" | sed -En 's/"count":\s*([0-9]+)/\1/ p')
+			count=$(echo "$check_result" | sed -En 's/^.*"count":\s*([0-9]+).*$/\1/ p')
 			if [[ $res -eq 0 && "$count" -ge 1 ]]; then
 				# Any nonzero object count means present.
 				# Some rclone backends support multiple

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -225,7 +225,10 @@ while read -r line; do
 				fi
 			else
 				res="$?"
-				# see https://rclone.org/docs/#exit-code
+				# res now contains the exit code of rclone (left-hand-side of && in if) or grep (right-hand-side of && in if)
+				# GNU grep manual says: the exit status is 0 if a line is selected, 1 if no lines were selected, and 2 if an error occurred.
+				# So for values above 2, res should be the exit code of rclone.
+				# See https://rclone.org/docs/#exit-code for rclone's exit codes.
 				if [[ "$res" == "3" ]] || [[ "$res" == "4" ]]; then
 					# file or directory doesn't exist
 					echo CHECKPRESENT-FAILURE "$key"

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -212,30 +212,24 @@ while read -r line; do
 		CHECKPRESENT)
 			key="$2"
 			calclocation "$key"
-
-			# Any nonzero object count means present.
-			# Some rclone backends support multiple
-			# files under one name.
-			if check_result=$(rclone size --json "$LOC$key" 2>&1) &&
-			    echo "$check_result" | GREP '"count":'; then
-				if echo "$check_result" | GREP -E '"count":\s*[1-9][0-9]*'; then
-					echo CHECKPRESENT-SUCCESS "$key"
-				else
-					echo CHECKPRESENT-FAILURE "$key"
-				fi
+			
+			res=0
+			check_result=$(rclone size --json "$LOC$key") || res=$?
+			count=$(echo "$check_result" | sed -En 's/"count":\s*([0-9]+)/\1/ p')
+			if [[ $res -eq 0 && "$count" -ge 1 ]]; then
+				# Any nonzero object count means present.
+				# Some rclone backends support multiple
+				# files under one name.
+				echo CHECKPRESENT-SUCCESS "$key"
+			elif [[ $res -eq 0 && -n "$count" && "$count" -eq 0 ]]; then
+				# A 0 object count means an empty directory.
+				echo CHECKPRESENT-FAILURE "$key"
+			elif [[ $res -eq 3 || $res -eq 4 ]]; then
+				# file or directory doesn't exist
+				# see https://rclone.org/docs/#exit-code
+				echo CHECKPRESENT-FAILURE "$key"
 			else
-				res="$?"
-				# res now contains the exit code of rclone (left-hand-side of && in if) or grep (right-hand-side of && in if)
-				# GNU grep manual says: the exit status is 0 if a line is selected, 1 if no lines were selected, and 2 if an error occurred.
-				# So for values above 2, res should be the exit code of rclone.
-				# See https://rclone.org/docs/#exit-code for rclone's exit codes.
-				if [[ "$res" == "3" ]] || [[ "$res" == "4" ]]; then
-					# file or directory doesn't exist
-					echo CHECKPRESENT-FAILURE "$key"
-				else
-					# some other error occured (e.g. a network error)
-					echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
-				fi
+				echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
 			fi
 		;;
 		REMOVE)

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -217,8 +217,8 @@ while read -r line; do
 			# Some rclone backends support multiple
 			# files under one name.
 			if check_result=$(rclone size --json "$LOC$key" 2>&1) &&
-			    echo "$check_result" | grep '"count":' >/dev/null; then
-				if echo "$check_result" | grep -E '"count":\s*[1-9][0-9]*' >/dev/null; then
+			    echo "$check_result" | GREP '"count":'; then
+				if echo "$check_result" | GREP -E '"count":\s*[1-9][0-9]*'; then
 					echo CHECKPRESENT-SUCCESS "$key"
 				else
 					echo CHECKPRESENT-FAILURE "$key"

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -224,12 +224,15 @@ while read -r line; do
 					echo CHECKPRESENT-FAILURE "$key"
 				fi
 			else
-				# When the directory does not exist,
-				# the remote is not available.
-				# (A network remote would similarly
-				# fail with CHECKPRESENT-UNKNOWN
-				# if it couldn't be contacted).
-				echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
+                                res="$?"
+                                if [[ "$res" == "3" ]]; then
+                                  # directory doesn't exist
+                                  echo CHECKPRESENT-FAILURE "$key"
+                                else
+                                  # some other error occured (e.g. a network error)
+                                  echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
+                                fi
+
 			fi
 		;;
 		REMOVE)

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -108,6 +108,7 @@ GREP () {
 	rc=$?
 	set -e
 	printcmdresult "grep \"$*\"" "$rc" "$out"
+	return $rc
 }
 
 # This has to come first, to get the protocol started.
@@ -247,8 +248,7 @@ while read -r line; do
 			if remove_result=$(rclone delete --retries 1 "$LOC$key" 2>&1); then
 				echo REMOVE-SUCCESS "$key"
 			else
-				if echo "$remove_result" | GREP ' directory not found'
-				then
+				if echo "$remove_result" | GREP ' directory not found'; then
 					echo REMOVE-SUCCESS "$key"
 				else
 					echo REMOVE-FAILURE "$key"

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -90,18 +90,24 @@ ask () {
 	fi
 }
 
-GREP () {
-	set +e
-	out=$(grep "$@")
-	rc=$?
-	set -e
+printcmdresult() {
+	cmd="$1"
+	rc="$2"
+	out="$3"
 	# Replace explicit newline since we must provide 1 line DEBUG
 	# Fancy sed is from Example 5 of https://linuxhint.com/newline_replace_sed
 	# which worked on Linux and OSX.
 	# shellcheck disable=SC2016
 	out_safe=$(echo "$out" | sed -ne 'H;${x;s/\n/\\n/g;s/^,//;p;}')
-	echo "DEBUG 'grep \"$*\"' exited with rc=$rc and stdout=${out_safe}"
-	exit $rc
+	echo "DEBUG '$cmd' exited with rc=$rc and stdout=${out_safe}"
+}
+
+GREP () {
+	set +e
+	out=$(grep "$@")
+	rc=$?
+	set -e
+	printcmdresult "grep \"$*\"" "$rc" "$out"
 }
 
 # This has to come first, to get the protocol started.
@@ -214,7 +220,8 @@ while read -r line; do
 			calclocation "$key"
 			
 			res=0
-			check_result=$(rclone size --json "$LOC$key") || res=$?
+			check_result=$(rclone size --json "$LOC$key" 2>/dev/null) || res=$?
+			printcmdresult "rclone size --json \"$LOC$key\"" "$res" "$check_result"
 			count=$(echo "$check_result" | sed -En 's/^.*"count":\s*([0-9]+).*$/\1/ p')
 			if [[ $res -eq 0 && "$count" -ge 1 ]]; then
 				# Any nonzero object count means present.

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -247,12 +247,7 @@ while read -r line; do
 			if remove_result=$(rclone delete --retries 1 "$LOC$key" 2>&1); then
 				echo REMOVE-SUCCESS "$key"
 			else
-				# rclone 1.29 used Failed to purge: Couldn't find directory:
-				# rclone 1.30 used no such file or directory
-				# rclone 1.33 uses directory not found
-				if echo "$remove_result" | GREP " Failed to purge: Couldn't find directory: " ||
-					echo "$remove_result" | GREP ' no such file or directory' ||
-					echo "$remove_result" | GREP ' directory not found'
+				if echo "$remove_result" | GREP ' directory not found'
 				then
 					echo REMOVE-SUCCESS "$key"
 				else

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -224,16 +224,15 @@ while read -r line; do
 					echo CHECKPRESENT-FAILURE "$key"
 				fi
 			else
-                                res="$?"
-                                # see https://rclone.org/docs/#exit-code
-                                if [[ "$res" == "3" ]] || [[ "$res" == "4" ]]; then
-                                  # file or directory doesn't exist
-                                  echo CHECKPRESENT-FAILURE "$key"
-                                else
-                                  # some other error occured (e.g. a network error)
-                                  echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
-                                fi
-
+				res="$?"
+				# see https://rclone.org/docs/#exit-code
+				if [[ "$res" == "3" ]] || [[ "$res" == "4" ]]; then
+					# file or directory doesn't exist
+					echo CHECKPRESENT-FAILURE "$key"
+				else
+					# some other error occured (e.g. a network error)
+					echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
+				fi
 			fi
 		;;
 		REMOVE)

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -225,8 +225,9 @@ while read -r line; do
 				fi
 			else
                                 res="$?"
-                                if [[ "$res" == "3" ]]; then
-                                  # directory doesn't exist
+                                # see https://rclone.org/docs/#exit-code
+                                if [[ "$res" == "3" ]] || [[ "$res" == "4" ]]; then
+                                  # file or directory doesn't exist
                                   echo CHECKPRESENT-FAILURE "$key"
                                 else
                                   # some other error occured (e.g. a network error)

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -216,23 +216,20 @@ while read -r line; do
 			# Any nonzero object count means present.
 			# Some rclone backends support multiple
 			# files under one name.
-			if check_result=$(rclone size "$LOC$key" 2>&1) &&
-				echo "$check_result" | GREP -E 'Total objects: [1-9][0-9]*\>'; then
-				echo CHECKPRESENT-SUCCESS "$key"
-			else
-				# rclone 1.29 used 'Total objects: 0'
-				# rclone 1.30 uses 'directory not found'
-				if echo "$check_result" | GREP 'Total objects: 0' ||
-				   echo "$check_result" | GREP ' directory not found'; then
-					echo CHECKPRESENT-FAILURE "$key"
+			if check_result=$(rclone size --json "$LOC$key" 2>&1) &&
+			    echo "$check_result" | grep '"count":' >/dev/null; then
+				if echo "$check_result" | grep -E '"count":\s*[1-9][0-9]*' >/dev/null; then
+					echo CHECKPRESENT-SUCCESS "$key"
 				else
-					# When the directory does not exist,
-					# the remote is not available.
-					# (A network remote would similarly
-					# fail with CHECKPRESENT-UNKNOWN
-					# if it couldn't be contacted).
-					echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
+					echo CHECKPRESENT-FAILURE "$key"
 				fi
+			else
+				# When the directory does not exist,
+				# the remote is not available.
+				# (A network remote would similarly
+				# fail with CHECKPRESENT-UNKNOWN
+				# if it couldn't be contacted).
+				echo CHECKPRESENT-UNKNOWN "$key" "remote currently unavailable or git-annex-remote-rclone failed to parse rclone output"
 			fi
 		;;
 		REMOVE)

--- a/tests/all-in-one.sh
+++ b/tests/all-in-one.sh
@@ -53,8 +53,9 @@ git-annex drop *
 git-annex get *
 
 # Do a cycle with --debug to ensure that we are passing desired DEBUG output
-git-annex --debug drop test\ 1 2>&1 | grep -q 'grep.*exited with rc='
+git-annex --debug drop test\ 1 2>&1 | grep -q 'rclone.*exited with rc='
 git-annex --debug get test\ 1 2>/dev/null
+git-annex --debug drop test\ 1 --from GA-rclone-CI 2>&1 | grep -q 'grep.*exited with rc='
 
 # test copy/drop/get cycle with parallel execution and good number of files and spaces in the names, and duplicated content/keys
 set +x

--- a/tests/all-in-one.sh
+++ b/tests/all-in-one.sh
@@ -52,6 +52,65 @@ git-annex copy * --to GA-rclone-CI
 git-annex drop *
 git-annex get *
 
+# Test REMOVE with mocked git-annex
+mkdir -p $RCLONE_PREFIX/abc/def
+echo test > $RCLONE_PREFIX/abc/def/test
+[[ -f $RCLONE_PREFIX/abc/def/test ]]
+mock-git-annex <<EOF
+< ^VERSION
+> PREPARE
+< ^GETCONFIG prefix$
+> VALUE $RCLONE_PREFIX
+< ^GETCONFIG target$
+> VALUE local
+< ^GETCONFIG rclone_layout$
+> VALUE lower
+< ^PREPARE-SUCCESS
+> REMOVE test
+< ^DIRHASH-LOWER test$
+> VALUE abc/def/
+< ^REMOVE-SUCCESS
+> REMOVE test
+< ^DIRHASH-LOWER test$
+> VALUE abc/def/
+< ^REMOVE-SUCCESS
+> REMOVE test2
+< ^DIRHASH-LOWER test2$
+> VALUE doe/sno/tex/ist/
+< ^REMOVE-SUCCESS
+EOF
+if [[ -f $RCLONE_PREFIX/abc/def/test ]]; then
+	echo "E: REMOVE failed to actually remove file"
+	exit 1
+fi
+
+# Test CHECKPRESENT with mocked git-annex
+mkdir -p $RCLONE_PREFIX/abc/def
+echo test > $RCLONE_PREFIX/abc/def/test
+mock-git-annex <<EOF
+< ^VERSION
+> PREPARE
+< ^GETCONFIG prefix$
+> VALUE $RCLONE_PREFIX
+< ^GETCONFIG target$
+> VALUE local
+< ^GETCONFIG rclone_layout$
+> VALUE lower
+< ^PREPARE-SUCCESS
+> CHECKPRESENT test
+< ^DIRHASH-LOWER test$
+> VALUE abc/def/
+< ^CHECKPRESENT-SUCCESS
+> CHECKPRESENT test-non-existing
+< ^DIRHASH-LOWER test-non-existing$
+> VALUE abc/def/
+< ^CHECKPRESENT-FAILURE
+> CHECKPRESENT test-non-existing-dir
+< ^DIRHASH-LOWER test-non-existing-dir$
+> VALUE dir/doe/sno/tex/ist/
+< ^CHECKPRESENT-FAILURE
+EOF
+
 # Do a cycle with --debug to ensure that we are passing desired DEBUG output
 git-annex --debug drop test\ 1 2>&1 | grep -q 'rclone.*exited with rc='
 git-annex --debug get test\ 1 2>/dev/null

--- a/tests/mock-git-annex
+++ b/tests/mock-git-annex
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Helper for simulating of the git-annex external remote protocol.
 # Starts git-annex-remote-rclone and checks its behaviour against a script
@@ -17,6 +17,7 @@
 set -e
 
 me=$(basename -- "$0")
+cd "$(mktemp -d ${TMPDIR:-/tmp}/garr-XXXXXXX)"
 
 msg() {
 	local fmt="$1"
@@ -28,6 +29,7 @@ msg() {
 # coproc alternative for ancient bash on macos:
 mkfifo pipe-remote-in
 mkfifo pipe-remote-out
+trap "rm -f pipe-remote-in pipe-remote-out" EXIT
 git-annex-remote-rclone < pipe-remote-in > pipe-remote-out &
 COPROC_PID=$!
 exec 4> pipe-remote-in
@@ -37,7 +39,7 @@ COPROC=(3 4)
 read_real_line() {
 	line=DEBUG
 	while printf '%s\n' "$line" | grep '^DEBUG' >/dev/null; do
-		read -u ${COPROC[0]} -r line
+		read -u "${COPROC[0]}" -r line
 		msg 'Got %s\n' "$line"
 	done
 	printf '%s\n' "$line"
@@ -49,13 +51,13 @@ while read -r command; do
 	if printf '%s\n' "$command" | grep '^>' >/dev/null; then
 		to_send=${command#>$' '*}
 		msg 'Sending %s\n' "$to_send"
-		printf '%s\n' "$to_send" >&${COPROC[1]}
+		printf '%s\n' "$to_send" >&"${COPROC[1]}"
 	elif printf '%s\n' "$command" | grep '^<' >/dev/null; then
 		to_match=${command#<$' '*}
 		msg 'Reading a line...\n'
 		line=$(read_real_line)
 		msg 'Checking against %s' "$to_match"
-		if printf "%s\n" "$line" | egrep -- "$to_match" >/dev/null; then
+		if printf "%s\n" "$line" | grep -E -- "$to_match" >/dev/null; then
 			printf ' :)\n' >&2
 		else
 			printf ' :(\n' >&2

--- a/tests/mock-git-annex
+++ b/tests/mock-git-annex
@@ -17,7 +17,7 @@
 set -e
 
 me=$(basename -- "$0")
-cd "$(mktemp -d ${TMPDIR:-/tmp}/garr-XXXXXXX)"
+cd "$(mktemp -d "${TMPDIR:-/tmp}/garr-XXXXXXX")"
 
 msg() {
 	local fmt="$1"
@@ -29,12 +29,18 @@ msg() {
 # coproc alternative for ancient bash on macos:
 mkfifo pipe-remote-in
 mkfifo pipe-remote-out
-trap "rm -f pipe-remote-in pipe-remote-out" EXIT
 git-annex-remote-rclone < pipe-remote-in > pipe-remote-out &
 COPROC_PID=$!
 exec 4> pipe-remote-in
 exec 3< pipe-remote-out
 COPROC=(3 4)
+coproc_cleanup() {
+	exec 3<&-
+	exec 4>&-
+	kill "$COPROC_PID"
+	rm -f pipe-remote-in pipe-remote-out
+}
+trap coproc_cleanup EXIT
 
 read_real_line() {
 	line=DEBUG
@@ -69,13 +75,4 @@ while read -r command; do
 	fi
 done
 
-exec 3<&- # fake coproc cleanup
-exec 4>&- # fake coproc cleanup
 msg 'Done.\n'
-set +e
-kill $COPROC_PID
-wait $COPROC_PID
-set -e
-rm pipe-remote-in  # fake coproc cleanup
-rm pipe-remote-out # fake coproc cleanup
-

--- a/tests/mock-git-annex
+++ b/tests/mock-git-annex
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Helper for simulating of the git-annex external remote protocol.
+# Starts git-annex-remote-rclone and checks its behaviour against a script
+# read from stdin. Each line of the script is either:
+#
+# > COMMAND ARG ARG
+#     A literal command to send to git-annex-remote-rclone.
+#
+# < REGEX
+#     A grep -E compatible regex to match against a line read from
+#     git-annex-remote-rclone. DEBUG lines are ignored.
+#     If the match fails, the simulator exits with exit code 1.
+#
+# Any other kind of line makes the simulator exit with exit code 2.
+
+set -e
+
+me=$(basename -- "$0")
+
+msg() {
+	local fmt="$1"
+	shift
+	printf "%q: $fmt" "$me" "$@" >&2
+}
+
+# coproc git-annex-remote-rclone 2>/dev/null
+# coproc alternative for ancient bash on macos:
+mkfifo pipe-remote-in
+mkfifo pipe-remote-out
+git-annex-remote-rclone < pipe-remote-in > pipe-remote-out &
+COPROC_PID=$!
+exec 4> pipe-remote-in
+exec 3< pipe-remote-out
+COPROC=(3 4)
+
+read_real_line() {
+	line=DEBUG
+	while printf '%s\n' "$line" | grep '^DEBUG' >/dev/null; do
+		read -u ${COPROC[0]} -r line
+		msg 'Got %s\n' "$line"
+	done
+	printf '%s\n' "$line"
+}
+
+while read -r command; do
+	# Strip trailing carriage return, if present
+	command="${command%$'\r'}"
+	if printf '%s\n' "$command" | grep '^>' >/dev/null; then
+		to_send=${command#>$' '*}
+		msg 'Sending %s\n' "$to_send"
+		printf '%s\n' "$to_send" >&${COPROC[1]}
+	elif printf '%s\n' "$command" | grep '^<' >/dev/null; then
+		to_match=${command#<$' '*}
+		msg 'Reading a line...\n'
+		line=$(read_real_line)
+		msg 'Checking against %s' "$to_match"
+		if printf "%s\n" "$line" | egrep -- "$to_match" >/dev/null; then
+			printf ' :)\n' >&2
+		else
+			printf ' :(\n' >&2
+			exit 1
+		fi
+	else
+		msg 'Wrong usage.\n'
+		exit 2
+	fi
+done
+
+exec 3<&- # fake coproc cleanup
+exec 4>&- # fake coproc cleanup
+msg 'Done.\n'
+set +e
+kill $COPROC_PID
+wait $COPROC_PID
+set -e
+rm pipe-remote-in  # fake coproc cleanup
+rm pipe-remote-out # fake coproc cleanup
+


### PR DESCRIPTION
This is actually <https://github.com/Craeckie/git-annex-remote-rclone> but updated against the current master.

I needed these changes to fix two problems I had with the OneDrive backend when running `git annex sync --content`:

- It reported `Failed to size with 2 errors: last error was: directory not found` for each uploaded file, although the data did seem to end up on OneDrive.
- It fails on files for which it failed earlier. I haven't investigated much but I'm guessing once an earlier sync got interrupted, then checking whether the file is already present on OneDrive kept failing.

Before merging this it's probably a good idea to run the tests :) How do I do that?