### PR TITLE
Add support for simple export protocol

### DIFF
--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -77,6 +77,10 @@ calclocation () {
 	esac
 }
 
+calcexportlocation() {
+	RET="$REMOTE_TARGET:$REMOTE_PREFIX/$1"
+}
+
 # Asks for some value, and stores it in RET
 ask () {
 	echo "$1" "$2"
@@ -203,6 +207,9 @@ while read -r line; do
 				echo INITREMOTE-FAILURE "Failed to create directory on remote. Ensure that 'rclone config' has been run."
 			fi
 		;;
+		EXPORTSUPPORTED)
+			echo EXPORTSUPPORTED-SUCCESS
+		;;
 		PREPARE)
 			# Use GETCONFIG to get configuration settings,
 			# and do anything needed to get ready for using the
@@ -219,6 +226,11 @@ while read -r line; do
 			validate_layout
 
 			echo PREPARE-SUCCESS
+		;;
+		EXPORT)
+			arg="${line:7}"
+			calcexportlocation "$arg"
+			EXPORT_LOC="$RET"
 		;;
 		TRANSFER)
 			op="$2"
@@ -258,17 +270,79 @@ while read -r line; do
 				;;
 			esac
 		;;
+		TRANSFEREXPORT)
+			op="$2"
+			key="$3"
+			file="$4"
+			case "$op" in
+				STORE)
+					# Store the file to a temporary location based on the key
+					# and then move it to the final destination, hopefully atomically
+					# XXX when at all possible, send PROGRESS
+					calcexportlocation ".tmp/$key"
+					tmploc="$RET"
+					if [ ! -e "$file" ]; then
+						echo TRANSFER-FAILURE STORE "$key" "asked to store non-existent file $file"
+					elif ! runcmd rclone copyto "$file" "$tmploc"; then
+						echo TRANSFER-FAILURE STORE "$key" "upload failed"
+					else
+						if ! runcmd rclone moveto "$tmploc" "$EXPORT_LOC"; then
+							runcmd rclone delete "$tmploc"
+							echo TRANSFER-FAILURE STORE "$key" "move to final destination failed"
+						else
+							echo TRANSFER-SUCCESS STORE "$key"
+						fi
+					fi
+				;;
+				RETRIEVE)
+					# Retrieve from the specified location
+					# outputting to the file.
+					# XXX when easy to do, send PROGRESS
+					# http://stackoverflow.com/questions/31396985/why-is-mktemp-on-os-x-broken-with-a-command-that-worked-on-linux
+					if GA_RC_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rclone-annex-tmp.XXXXXXXXX") &&
+						runcmd rclone copyto "$EXPORT_LOC" "$GA_RC_TEMP_DIR/$key" &&
+						mv "$GA_RC_TEMP_DIR/$key" "$file" &&
+						rmdir "$GA_RC_TEMP_DIR"; then
+						echo TRANSFER-SUCCESS RETRIEVE "$key"
+					else
+						echo TRANSFER-FAILURE RETRIEVE "$key"
+					fi
+				;;
+			esac
+		;;
 		CHECKPRESENT)
 			key="$2"
 			calclocation "$key"
 
 			do_checkpresent "$key" "$LOC$key"
 		;;
+		CHECKPRESENTEXPORT)
+			key="$2"
+
+			do_checkpresent "$key" "$EXPORT_LOC"
+		;;
 		REMOVE)
 			key="$2"
 			calclocation "$key"
 
 			do_remove "$key" "$LOC$key"
+		;;
+		REMOVEEXPORT)
+			key="$2"
+
+			do_remove "$key" "$EXPORT_LOC"
+		;;
+		RENAMEEXPORT)
+			key="$2"
+			arg="$(echo "$line" |cut -d' ' -f3-)"
+			calcexportlocation "$arg"
+			newname="$RET"
+
+			if runcmd rclone moveto "$EXPORT_LOC" "$newname"; then
+				echo RENAMEEXPORT-SUCCESS "$key"
+			else
+				echo RENAMEEXPORT-FAILURE "$key"
+			fi
 		;;
 		*)
 			# The requests listed above are all the ones

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -276,11 +276,13 @@ while read -r line; do
 			file="$4"
 			case "$op" in
 				STORE)
-					# Store the file to a temporary location based on the key
-					# and then move it to the final destination, hopefully atomically
+					# Store the file to a temporary location next to the final destination,
+					# and then move it to the final destination, hopefully atomically.
+					# 16 bytes from /dev/urandom is 128 bits, or 32 hexdigits after hashing
+					rand=$(head -c 16 /dev/urandom |git hash-object --stdin)
+					tmploc="${EXPORT_LOC}.tmp-${rand:0:32}"
+
 					# XXX when at all possible, send PROGRESS
-					calcexportlocation ".tmp/$key"
-					tmploc="$RET"
 					if [ ! -e "$file" ]; then
 						echo TRANSFER-FAILURE STORE "$key" "asked to store non-existent file $file"
 					elif ! runcmd rclone copyto "$file" "$tmploc"; then

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -157,6 +157,14 @@ do_remove() {
 	fi
 }
 
+abort_annex_race_bug() {
+	url="https://git-annex.branchable.com/bugs/external_remote_export_sent_to_wrong_process/"
+	msg="DETECTED GIT-ANNEX BUG! ${*}! please update your git-annex to 10.20230329 or later, for details see: ${url}"
+	echo "ERROR $msg"
+	echo "$msg" >&2
+	exit 2
+}
+
 # This has to come first, to get the protocol started.
 echo VERSION 1
 
@@ -225,9 +233,16 @@ while read -r line; do
 			RCLONE_LAYOUT="$RET"
 			validate_layout
 
+			GOT_EXPORT=""
+
 			echo PREPARE-SUCCESS
 		;;
 		EXPORT)
+			if [ -n "$GOT_EXPORT" ]; then
+				abort_annex_race_bug "received two EXPORT requests in a row" || exit 2
+			fi
+			GOT_EXPORT="y"
+
 			arg="${line:7}"
 			calcexportlocation "$arg"
 			EXPORT_LOC="$RET"
@@ -271,6 +286,11 @@ while read -r line; do
 			esac
 		;;
 		TRANSFEREXPORT)
+			if [ -z "$GOT_EXPORT" ]; then
+				abort_annex_race_bug "received TRANSFEREXPORT without prior EXPORT" || exit 2
+			fi
+			GOT_EXPORT=""
+
 			op="$2"
 			key="$3"
 			file="$4"
@@ -319,6 +339,11 @@ while read -r line; do
 			do_checkpresent "$key" "$LOC$key"
 		;;
 		CHECKPRESENTEXPORT)
+			if [ -z "$GOT_EXPORT" ]; then
+				abort_annex_race_bug "received CHECKPRESENTEXPORT without prior EXPORT" || exit 2
+			fi
+			GOT_EXPORT=""
+
 			key="$2"
 
 			do_checkpresent "$key" "$EXPORT_LOC"
@@ -330,11 +355,21 @@ while read -r line; do
 			do_remove "$key" "$LOC$key"
 		;;
 		REMOVEEXPORT)
+			if [ -z "$GOT_EXPORT" ]; then
+				abort_annex_race_bug "received REMOVEEXPORT without prior EXPORT" || exit 2
+			fi
+			GOT_EXPORT=""
+
 			key="$2"
 
 			do_remove "$key" "$EXPORT_LOC"
 		;;
 		RENAMEEXPORT)
+			if [ -z "$GOT_EXPORT" ]; then
+				abort_annex_race_bug "received RENAMEEXPORT without prior EXPORT" || exit 2
+			fi
+			GOT_EXPORT=""
+
 			key="$2"
 			arg="$(echo "$line" |cut -d' ' -f3-)"
 			calcexportlocation "$arg"


### PR DESCRIPTION
as specified in:  https://git-annex.branchable.com/design/external_special_remote_protocol/export_and_import_appendix/

I believe if merged, this would close #30 and #35.

I extracted some code into the `do_checkpresent` and `do_remove` functions to avoid copy-pasting - should that go in a separate commit, or is it ok as is?

I've tested the new functionality locally with an FTP remote, but haven't written any automated tests for it. I'll try to add some if necessary.