### PR TITLE
Enable windows-latest and setup msys2 with git-annex there

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          #- windows-2019
+          - windows-latest
           - macos-latest
         rclone:
           - current
@@ -47,6 +47,18 @@ jobs:
     - name: Install git-annex (macOS)
       if: startsWith(matrix.os, 'macos-')
       run: datalad-installer git-annex -m brew
+
+    - name: Set up MSYS2 (Windows)
+      if: startsWith(matrix.os, 'windows-')
+      uses: actions/setup-msys2@v1
+      with:
+        msys2-root: C:\msys64
+
+    - name: Install git-annex (Windows)
+      if: startsWith(matrix.os, 'windows-')
+      run: |
+        pacman -Sy
+        pacman -S git-annex
 
     - name: Install latest rclone
       if: matrix.rclone == 'current'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,6 @@ jobs:
 
     - name: ${{ matrix.module }} tests
       run: |
-        PATH=$PWD:$PWD/tests:$PATH all-in-one.sh
+        PATH=${PWD}:${PWD}/tests:${PATH} all-in-one.sh
         # Test without encryption so we do get 0-sized files in rclone remote store
-        PATH=$PWD:$PWD/tests:$PATH GARR_TEST_ENCRYPTION=none all-in-one.sh
+        PATH=${PWD}:${PWD}/tests:${PATH} GARR_TEST_ENCRYPTION=none all-in-one.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,15 +50,12 @@ jobs:
 
     - name: Set up MSYS2 (Windows)
       if: startsWith(matrix.os, 'windows-')
-      uses: actions/setup-msys2@v1
+      uses: msys2/setup-msys2@v2
       with:
-        msys2-root: C:\msys64
-
-    - name: Install git-annex (Windows)
-      if: startsWith(matrix.os, 'windows-')
-      run: |
-        pacman -Sy
-        pacman -S git-annex
+        update: true
+        install: >-
+          bash
+          git-annex
 
     - name: Install latest rclone
       if: matrix.rclone == 'current'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,10 +48,6 @@ jobs:
       if: startsWith(matrix.os, 'macos-')
       run: datalad-installer git-annex -m brew
 
-    - name: Set up MSYS2 (Windows)
-      if: startsWith(matrix.os, 'windows-')
-      uses: msys2/setup-msys2@v2
-    
     - name: Install git-annex (Windows)
       if: startsWith(matrix.os, 'windows-')
       run: datalad-installer --sudo ok git-annex

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,10 @@ jobs:
     - name: Set up MSYS2 (Windows)
       if: startsWith(matrix.os, 'windows-')
       uses: msys2/setup-msys2@v2
-      with:
-        update: true
-        install: >-
-          bash
-          git-annex
+    
+    - name: Install git-annex (Windows)
+      if: startsWith(matrix.os, 'windows-')
+      run: datalad-installer --sudo ok git-annex
 
     - name: Install latest rclone
       if: matrix.rclone == 'current'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,15 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          # - ubuntu-18.04
           - windows-latest
-          - macos-latest
+          # - macos-latest
         rclone:
           - current
-          - v1.59.2
-          - v1.58.1
-          - v1.53.3  # Debian bullseye (current stable)
-          - v1.45    # Debian buster (current oldstable)
+          # - v1.59.2
+          # - v1.58.1
+          # - v1.53.3  # Debian bullseye (current stable)
+          # - v1.45    # Debian buster (current oldstable)
         exclude:
           # 1.45 - has some odd handling of HOME on OSX - does not use overloaded $HOME
           - os: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
       run: datalad-installer --sudo ok rclone=${{ matrix.rclone }} -m downloads.rclone.org
 
     - name: ${{ matrix.module }} tests
+      shell: bash
       run: |
         PATH=${PWD}:${PWD}/tests:${PATH} all-in-one.sh
         # Test without encryption so we do get 0-sized files in rclone remote store

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Install latest rclone
       if: matrix.rclone == 'current'
-      run: datalad-installer --sudo ok rclone -m downloads.rclone.org
+      run: datalad-installer --sudo ok rclone --bin-dir C:\rclone -m downloads.rclone.org
 
     - name: Install specific version of rclone
       if: matrix.rclone != 'current'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Install latest rclone
       if: matrix.rclone == 'current'
-      run: datalad-installer --sudo ok rclone --bin-dir C:\rclone -m downloads.rclone.org
+      run: datalad-installer --sudo ok rclone --bin-dir "C:\Program Files\Git\usr\bin" -m downloads.rclone.org
 
     - name: Install specific version of rclone
       if: matrix.rclone != 'current'


### PR DESCRIPTION
I am somewhat following chatgpt on when I asked it to setup msys2 env on windows, so to say -- I do not know what I am doing.  But it was inspired by dialog in https://github.com/git-annex-remote-rclone/git-annex-remote-rclone/pull/62 and discovery that /dev/urandom should be available there