### PR TITLE
Get progress report from rclone log file and channel it to git-annex

### DIFF
--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -118,6 +118,39 @@ get_json_int() {
 	echo "$json_string" | sed -En "s/^.*\"$key\":\s*([0-9]+).*$/\1/p"
 }
 
+# Function to monitor rclone progress and report back to git-annex
+rclone_progress() {
+	# Create a temporary file for the log
+	log_file=$(mktemp "${TMPDIR:-/tmp}/rclone-annex-tmp.XXXXXXXXX")
+
+	# Run rclone with the specified options and log to the temporary file
+	rclone "$@" --use-json-log --stats-log-level NOTICE --stats 1s --log-file "$log_file" &
+	rclone_pid=$!
+
+	# Monitor the log file for changes and extract the "bytes" field
+	tail -fn0 "$log_file" | while IFS= read -r line; do
+		bytes=$(get_json_int "$line" "bytes")
+		if [[ -n $bytes ]]; then
+			echo "PROGRESS $bytes"
+		fi
+
+		# Check if rclone process is still running
+		if ! ps -p $rclone_pid > /dev/null; then
+			break
+		fi
+	done
+
+	# Wait for rclone to finish and capture its exit code
+	wait $rclone_pid
+	exit_code=$?
+
+	# Clean up the log file
+	[ -e "$log_file" ] && rm "$log_file"
+
+	# Return the exit code of the rclone command
+	return $exit_code
+}
+
 do_checkpresent() {
 	key="$1"
 	dest="$2"
@@ -241,7 +274,7 @@ while read -r line; do
 					if [ ! -e "$file" ]; then
 						echo TRANSFER-FAILURE STORE "$key" "asked to store non-existent file $file"
 					else
-						if runcmd rclone copy "$file" "$LOC"; then
+						if rclone_progress copy "$file" "$LOC"; then
 							echo TRANSFER-SUCCESS STORE "$key"
 						else
 							echo TRANSFER-FAILURE STORE "$key"
@@ -255,7 +288,7 @@ while read -r line; do
 					calclocation "$key"
 					# http://stackoverflow.com/questions/31396985/why-is-mktemp-on-os-x-broken-with-a-command-that-worked-on-linux
 					if GA_RC_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rclone-annex-tmp.XXXXXXXXX") &&
-						runcmd rclone copy "$LOC$key" "$GA_RC_TEMP_DIR" &&
+						rclone_progress copy "$LOC$key" "$GA_RC_TEMP_DIR" &&
 						mv "$GA_RC_TEMP_DIR/$key" "$file" &&
 						rmdir "$GA_RC_TEMP_DIR"; then
 						echo TRANSFER-SUCCESS RETRIEVE "$key"

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -111,6 +111,13 @@ GREP () {
 	return $rc
 }
 
+# Helper function to extract an integer value from a JSON string using sed
+get_json_int() {
+	json_string="$1"
+	key="$2"
+	echo "$json_string" | sed -En "s/^.*\"$key\":\s*([0-9]+).*$/\1/p"
+}
+
 do_checkpresent() {
 	key="$1"
 	dest="$2"
@@ -118,7 +125,7 @@ do_checkpresent() {
 	res=0
 	check_result=$(rclone size --json "$dest" 2>/dev/null) || res=$?
 	printcmdresult "rclone size --json \"$dest\"" "$res" "$check_result"
-	count=$(echo "$check_result" | sed -En 's/^.*"count":\s*([0-9]+).*$/\1/ p')
+	count=$(get_json_int "$check_result" count)
 	if [[ $res -eq 0 && "$count" -ge 1 ]]; then
 		# Any nonzero object count means present.
 		# Some rclone backends support multiple


### PR DESCRIPTION
That should  (I think) prevent git-annex from announcing that transfer stalled and killing remote while working on large files. Closes #76

ref on question on how to get progress report from rclone: https://forum.rclone.org/t/progress-json-or-progress-bytes-or-alike-to-simplify-parsing-of-progress/43840/4 where @ncw made us straight ;)

TODOs
- [x] see if we need to restrict this to not be used on some older `rclone` we still support
well -- all tests passed across those versions of rclone we have.  So  I guess it is all good.

- [x] verify that it works on some large file (e.g. on drogon as in that rclone support request)

verified:  it took awhile to get there since it was checking each chunk (we do 1GB chunks... should have done bigger - wasiting time now)m and then eventually started to grow after 200GiB

```shell
dandi@drogon:/mnt/backup/dandi/dandisets/000363$ PATH=/home/dandi/proj/git-annex-remote-rclone:$PATH  git annex move --to dandi-dandisets-dropbox sub-484676/sub-484676_ses-20210421T141806_behavior+ecephys+ogen.nwb
move sub-484676/sub-484676_ses-20210421T141806_behavior+ecephys+ogen.nwb (to dandi-dandisets-dropbox...)
50%   200.75 GiB       44 MiB/s 1h15m 
```
and I see `rclone` being invoked like

```
dandi    2307573 20.2  0.1 1332620 107148 pts/18 Sl   15:22   0:06 rclone copy .git/annex/tmp/SHA256E-s427515554212-S1000000000-C217--2fe7839029026f34e806553c4a6403665cbb14c16c4c4b67c3afc0053f7babac.nwb dandi-dandisets-dropbox:dandi-dandisets/annexstore/e31/18f/ --use-json-log --stats-log-level NOTICE --stats 1s --log-file /tmp/rclone-annex-tmp.a3lvlI7vE
```

I will leave it open for a day or two for possible reviews/feedback, but otherwise it seems to be ready!