### PR TITLE
Support for rclone options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ The build badge above is linked to this CI process.
  ```
  RCLONE_CONFIG_PASS=your_password_here git annex ...
  ```
+  or
  
+`rclone-options` can be used to pass --password-command
+
    Pull requests proposing a more secure or easier to use approach to password-protected `rclone` configurations are welcome.
   
 3. Create a git-annex repository ([walkthrough](https://git-annex.branchable.com/walkthrough/))
@@ -85,6 +88,15 @@ The build badge above is linked to this CI process.
 ```
 git annex initremote myacdremote type=external externaltype=rclone target=acd prefix=git-annex chunk=50MiB encryption=shared mac=HMACSHA512 rclone_layout=lower
 ```
+
+else with rclone_options for `--password-command` option
+
+
+```
+git annex initremote myacdremote type=external externaltype=rclone target=acd prefix=git-annex chunk=50MiB encryption=shared mac=HMACSHA512 rclone_layout=lower \
+    rclone_options="--password-command='secret-tool lookup rclone gcrypt'"
+```
+
 
 The initremote command calls out to GPG and can hang if a machine has insufficient entropy. To debug issues, use the `--debug` flag, i.e. `git-annex initremote --debug`.
 

--- a/git-annex-remote-rclone
+++ b/git-annex-remote-rclone
@@ -124,7 +124,7 @@ rclone_progress() {
 	log_file=$(mktemp "${TMPDIR:-/tmp}/rclone-annex-tmp.XXXXXXXXX")
 
 	# Run rclone with the specified options and log to the temporary file
-	rclone "$@" --use-json-log --stats-log-level NOTICE --stats 1s --log-file "$log_file" &
+	rclone $RCLONE_OPTIONS "$@" --use-json-log --stats-log-level NOTICE --stats 1s --log-file "$log_file" &
 	rclone_pid=$!
 
 	# Monitor the log file for changes and extract the "bytes" field
@@ -156,8 +156,8 @@ do_checkpresent() {
 	dest="$2"
 
 	res=0
-	check_result=$(rclone size --json "$dest" 2>/dev/null) || res=$?
-	printcmdresult "rclone size --json \"$dest\"" "$res" "$check_result"
+	check_result=$(rclone $RCLONE_OPTIONS size --json "$dest" 2>/dev/null) || res=$?
+	printcmdresult "rclone $RCLONE_OPTIONS size --json \"$dest\"" "$res" "$check_result"
 	count=$(get_json_int "$check_result" count)
 	if [[ $res -eq 0 && "$count" -ge 1 ]]; then
 		# Any nonzero object count means present.
@@ -182,7 +182,7 @@ do_remove() {
 
 	# Note that it's not a failure to remove a
 	# key that is not present.
-	if remove_result=$(rclone delete --retries 1 "$dest" 2>&1); then
+	if remove_result=$(rclone $RCLONE_OPTIONS delete --retries 1 "$dest" 2>&1); then
 		echo REMOVE-SUCCESS "$key"
 	else
 		if echo "$remove_result" | GREP ' directory not found'; then
@@ -233,11 +233,15 @@ while read -r line; do
 			validate_layout
 			setconfig rclone_layout "$RCLONE_LAYOUT"
 
+			getconfig rclone_options
+			RCLONE_OPTIONS="$RET"
+			setconfig rclone_options "$RCLONE_OPTIONS"
+
 			if [ -z "$REMOTE_TARGET" ]; then
 				echo INITREMOTE-FAILURE "rclone remote target must be specified (use target= parameter)"
 			fi
 
-			if runcmd rclone mkdir "$REMOTE_TARGET:$REMOTE_PREFIX"; then
+			if runcmd rclone $RCLONE_OPTIONS mkdir "$REMOTE_TARGET:$REMOTE_PREFIX"; then
 				echo INITREMOTE-SUCCESS
 			else
 				echo INITREMOTE-FAILURE "Failed to create directory on remote. Ensure that 'rclone config' has been run."
@@ -257,6 +261,9 @@ while read -r line; do
 			getconfig rclone_layout
 			RCLONE_LAYOUT="$RET"
 			validate_layout
+
+			getconfig rclone_options
+			RCLONE_OPTIONS="$RET"
 
 			echo PREPARE-SUCCESS
 		;;


### PR DESCRIPTION
Added support for rclone options, which could be utilize to pass option like --password-command

Usage

git annex initremote gcryptdrive \
    type=external externaltype=rclone \
    target=gcrypt:drive:secure-annex prefix=annex \
    rclone_options="--password-command='secret-tool lookup rclone gcrypt'" \
    encryption=none

or

git annex enableremote gcryptdrive
git annex setconfig gcryptdrive rclone_options \
    "--password-command='secret-tool lookup rclone gcrypt'"